### PR TITLE
auto-rollback based on git history

### DIFF
--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -22,6 +22,7 @@ The `upgrade` command applies all pending migrations to your database in order. 
 | `--skip-validation`          |       | Skip all validation checks                |
 | `--skip-checksum-validation` |       | Skip checksum validation only             |
 | `--skip-file-validation`     |       | Skip file validation only                 |
+| `--auto-rollback`            |       | Roll back missing migrations and re-upgrade (see below) |
 
 ## Examples
 
@@ -90,6 +91,30 @@ jetbase upgrade --skip-file-validation
 !!! warning
     Skipping validation can lead to inconsistent database state. Only use these options if you understand the implications.  
     To learn more, see [Validations](../validations/index.md).
+
+### Automatic Safe Rollback
+
+```bash
+jetbase upgrade --auto-rollback
+```
+
+Normally, if an *already-applied* migration's file is missing from your `migrations/`
+directory (for example, after checking out an older branch or release), the upgrade
+stops with an error. With `--auto-rollback`, Jetbase instead rolls the database back to
+the most recent applied migration whose file still exists, then re-runs the upgrade from
+that baseline.
+
+To do this safely, Jetbase records the git commit hash that was checked out when each
+migration was applied (in the `git_commit_hash` column of `jetbase_migrations`). When a
+file is missing, it recovers that migration's rollback SQL **read-only** from the recorded
+commit using `git show` — it never modifies your working tree or `HEAD`.
+
+!!! note
+    Automatic safe rollback requires that the repository is a git checkout and that the
+    latest applied migration has a recorded commit hash. If either is missing (for example,
+    migrations applied outside a git repository, or before this column existed), Jetbase
+    falls back to the standard behaviour and raises an error. The column is added
+    automatically to existing `jetbase_migrations` tables on the next upgrade.
 
 
 ## Migration Types

--- a/jetbase/cli/main.py
+++ b/jetbase/cli/main.py
@@ -49,6 +49,15 @@ def upgrade(
         "--skip-file-validation",
         help="Skip file version validation when running migrations",
     ),
+    auto_rollback: bool = typer.Option(
+        False,
+        "--auto-rollback",
+        help=(
+            "If an already-applied migration's file is missing, roll back to "
+            "the latest applied migration whose file exists (recovering rollback "
+            "SQL from the recorded git commit) and re-run the upgrade"
+        ),
+    ),
 ):
     """Execute pending migrations"""
     validate_jetbase_directory()
@@ -59,6 +68,7 @@ def upgrade(
         skip_validation=skip_validation,
         skip_checksum_validation=skip_checksum_validation,
         skip_file_validation=skip_file_validation,
+        auto_rollback=auto_rollback,
     )
 
 

--- a/jetbase/commands/safe_rollback.py
+++ b/jetbase/commands/safe_rollback.py
@@ -1,0 +1,141 @@
+import os
+import tempfile
+
+from jetbase.constants import MIGRATIONS_DIR
+from jetbase.engine.file_parser import parse_rollback_statements
+from jetbase.engine.git import get_repo_root, read_file_at_commit
+from jetbase.engine.lock import migration_lock
+from jetbase.engine.version import get_migration_filepaths_by_version
+from jetbase.enums import MigrationDirectionType
+from jetbase.logging import logger
+from jetbase.models import AppliedVersionedMigration
+from jetbase.repositories.migrations_repo import (
+    get_versioned_migrations_desc,
+    run_migration,
+)
+
+
+def attempt_safe_rollback() -> bool:
+    """
+    Roll the database back to the latest applied migration whose file exists.
+
+    Triggered when an upgrade finds that an already-applied migration's file
+    is missing locally. Rolls back the trailing applied migrations whose files
+    are absent, down to the most recent applied version that still has a file
+    (the new baseline). The rollback SQL for missing files is recovered
+    read-only from the git commit hash recorded on the latest applied
+    migration (it contained every earlier migration's file).
+
+    Falls back gracefully (returns False) when recovery is not possible, so
+    the caller can re-raise the original error and preserve old behaviour:
+    no applied migrations, not inside a git repository, the latest applied
+    migration has no recorded git commit hash, the missing files are not a
+    contiguous trailing run, or a file cannot be recovered from git.
+
+    Returns:
+        bool: True if the database was rolled back to a usable baseline,
+            False if no safe rollback could be performed.
+    """
+    applied: list[AppliedVersionedMigration] = get_versioned_migrations_desc()
+    if not applied:
+        return False
+
+    repo_root: str | None = get_repo_root()
+    latest_hash: str | None = applied[0].git_commit_hash
+    if repo_root is None or not latest_hash:
+        return False
+
+    migrations_dir: str = os.path.join(os.getcwd(), MIGRATIONS_DIR)
+    current_files: dict[str, str] = get_migration_filepaths_by_version(
+        directory=migrations_dir
+    )
+
+    to_rollback: list[AppliedVersionedMigration] = []
+    for migration in applied:
+        if migration.version in current_files:
+            break
+        to_rollback.append(migration)
+
+    if not to_rollback:
+        return False
+
+    logger.info(
+        "Detected missing migration file(s). Attempting safe rollback of: %s",
+        ", ".join(migration.version for migration in to_rollback),
+    )
+
+    with migration_lock():
+        for migration in to_rollback:
+            sql_statements: list[str] | None = _get_rollback_statements(
+                migration=migration,
+                current_files=current_files,
+                migrations_dir=migrations_dir,
+                repo_root=repo_root,
+                commit_hash=latest_hash,
+            )
+            if sql_statements is None:
+                logger.warning(
+                    "Could not recover rollback SQL for version %s from git. "
+                    "Aborting safe rollback.",
+                    migration.version,
+                )
+                return False
+
+            run_migration(
+                sql_statements=sql_statements,
+                version=migration.version,
+                migration_operation=MigrationDirectionType.ROLLBACK,
+                filename=migration.filename,
+            )
+            logger.info("Rollback applied successfully: %s", migration.filename)
+
+    return True
+
+
+def _get_rollback_statements(
+    migration: AppliedVersionedMigration,
+    current_files: dict[str, str],
+    migrations_dir: str,
+    repo_root: str,
+    commit_hash: str,
+) -> list[str] | None:
+    """
+    Get rollback SQL statements for a migration being safely rolled back.
+
+    Uses the local file when it still exists; otherwise recovers the file
+    content read-only from the given git commit and parses it.
+
+    Args:
+        migration (AppliedVersionedMigration): The migration to roll back.
+        current_files (dict[str, str]): Mapping of version to file path for
+            files that currently exist locally.
+        migrations_dir (str): Absolute path to the migrations directory.
+        repo_root (str): Absolute path to the git repository root.
+        commit_hash (str): The commit hash to recover missing files from.
+
+    Returns:
+        list[str] | None: The rollback SQL statements, or None if the file
+            could not be recovered from git.
+    """
+    local_path: str | None = current_files.get(migration.version)
+    if local_path is not None:
+        return parse_rollback_statements(file_path=local_path)
+
+    file_path: str = os.path.join(migrations_dir, migration.filename)
+    repo_relative_path: str = os.path.relpath(file_path, repo_root).replace(os.sep, "/")
+    content: str | None = read_file_at_commit(
+        commit_hash=commit_hash, repo_relative_path=repo_relative_path
+    )
+    if content is None:
+        return None
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".sql", delete=False
+    ) as temp_file:
+        temp_file.write(content)
+        temp_file_path: str = temp_file.name
+
+    try:
+        return parse_rollback_statements(file_path=temp_file_path)
+    finally:
+        os.unlink(temp_file_path)

--- a/jetbase/commands/upgrade.py
+++ b/jetbase/commands/upgrade.py
@@ -12,7 +12,9 @@ from jetbase.engine.validation import run_migration_validations
 from jetbase.engine.version import (
     get_migration_filepaths_by_version,
 )
+from jetbase.commands.safe_rollback import attempt_safe_rollback
 from jetbase.enums import MigrationDirectionType, MigrationType
+from jetbase.exceptions import MissingMigrationFileError
 from jetbase.logging import logger
 from jetbase.models import MigrationRecord
 from jetbase.repositories.lock_repo import create_lock_table_if_not_exists
@@ -33,6 +35,7 @@ def upgrade_cmd(
     skip_validation: bool = False,
     skip_checksum_validation: bool = False,
     skip_file_validation: bool = False,
+    auto_rollback: bool = False,
 ) -> None:
     """
     Apply pending migrations to the database in order.
@@ -44,6 +47,11 @@ def upgrade_cmd(
         skip_validation (bool): Skip all validations.
         skip_checksum_validation (bool): Skip checksum validation only.
         skip_file_validation (bool): Skip file validation only.
+        auto_rollback (bool): If an already-applied migration's file is
+            missing, automatically roll the database back to the latest
+            applied migration whose file still exists, then re-run the
+            upgrade from that baseline. Requires a git commit hash recorded
+            on the latest applied migration. Defaults to False.
 
     Raises:
         ValueError: If both count and to_version are specified.
@@ -62,15 +70,13 @@ def upgrade_cmd(
     create_migrations_table_if_not_exists()
     create_lock_table_if_not_exists()
 
-    latest_migration: MigrationRecord | None = fetch_latest_versioned_migration()
-
-    if latest_migration:
-        run_migration_validations(
-            latest_migrated_version=latest_migration.version,
-            skip_validation=skip_validation,
-            skip_checksum_validation=skip_checksum_validation,
-            skip_file_validation=skip_file_validation,
-        )
+    latest_migration: MigrationRecord | None = _run_validations_with_auto_rollback(
+        skip_validation=skip_validation,
+        skip_checksum_validation=skip_checksum_validation,
+        skip_file_validation=skip_file_validation,
+        auto_rollback=auto_rollback,
+        dry_run=dry_run,
+    )
 
     filepaths_by_version: dict[str, str] = _get_filepaths_by_version(
         latest_migration=latest_migration,
@@ -117,6 +123,69 @@ def upgrade_cmd(
             repeatable_always_filepaths=repeatable_always_filepaths,
             runs_on_change_filepaths=runs_on_change_filepaths,
         )
+
+
+def _run_validations_with_auto_rollback(
+    skip_validation: bool,
+    skip_checksum_validation: bool,
+    skip_file_validation: bool,
+    auto_rollback: bool,
+    dry_run: bool,
+) -> MigrationRecord | None:
+    """
+    Run pre-upgrade validations, optionally recovering from missing files.
+
+    Fetches the latest applied migration and runs validations. If a migrated
+    version's file is missing and auto-rollback is enabled for a real (non
+    dry-run) upgrade, attempts a safe rollback to the latest applied migration
+    whose file still exists, then re-validates from that baseline. If the safe
+    rollback cannot be performed, the original error is re-raised, preserving
+    the previous behaviour.
+
+    Args:
+        skip_validation (bool): Skip all validations.
+        skip_checksum_validation (bool): Skip checksum validation only.
+        skip_file_validation (bool): Skip file validation only.
+        auto_rollback (bool): Whether to attempt safe rollback on a missing
+            migration file.
+        dry_run (bool): Whether this is a dry-run upgrade (no auto-rollback).
+
+    Returns:
+        MigrationRecord | None: The latest applied migration after any
+            rollback, or None if no migrations are applied.
+
+    Raises:
+        MissingMigrationFileError: If a migrated version's file is missing and
+            a safe rollback was not performed.
+    """
+    latest_migration: MigrationRecord | None = fetch_latest_versioned_migration()
+
+    if not latest_migration:
+        return None
+
+    try:
+        run_migration_validations(
+            latest_migrated_version=latest_migration.version,
+            skip_validation=skip_validation,
+            skip_checksum_validation=skip_checksum_validation,
+            skip_file_validation=skip_file_validation,
+        )
+    except MissingMigrationFileError:
+        if dry_run or not auto_rollback:
+            raise
+        if not attempt_safe_rollback():
+            raise
+
+        latest_migration = fetch_latest_versioned_migration()
+        if latest_migration:
+            run_migration_validations(
+                latest_migrated_version=latest_migration.version,
+                skip_validation=skip_validation,
+                skip_checksum_validation=skip_checksum_validation,
+                skip_file_validation=skip_file_validation,
+            )
+
+    return latest_migration
 
 
 def _get_filepaths_by_version(

--- a/jetbase/database/queries/base.py
+++ b/jetbase/database/queries/base.py
@@ -58,6 +58,37 @@ class BaseQueries:
         return default_queries.DELETE_VERSION_STMT
 
     @staticmethod
+    def add_git_commit_hash_column_stmt() -> TextClause:
+        """
+        Get statement to add the nullable git_commit_hash column.
+
+        Used to upgrade pre-existing jetbase_migrations tables that were
+        created before the git_commit_hash column existed. The default uses
+        ADD COLUMN IF NOT EXISTS so it is a safe no-op when the column is
+        already present; dialects that do not support that clause override
+        this with a plain ALTER and let the caller tolerate the resulting
+        duplicate-column error.
+
+        Returns:
+            TextClause: SQLAlchemy text clause for the ALTER TABLE statement.
+        """
+        return default_queries.ADD_GIT_COMMIT_HASH_COLUMN_STMT
+
+    @staticmethod
+    def get_versioned_migrations_query() -> TextClause:
+        """
+        Get query to fetch versioned migrations newest-first.
+
+        Returns the version, filename, and git_commit_hash for every
+        versioned migration, ordered by execution order descending.
+
+        Returns:
+            TextClause: SQLAlchemy text clause returning version, filename,
+                and git_commit_hash columns.
+        """
+        return default_queries.GET_VERSIONED_MIGRATIONS_QUERY
+
+    @staticmethod
     def latest_versions_query() -> TextClause:
         """
         Get query to fetch the latest N migration versions.
@@ -129,13 +160,14 @@ class BaseQueries:
         """
         query: str = f"""
             SELECT
-                order_executed, 
-                version, 
+                order_executed,
+                version,
                 description,
                 filename,
                 migration_type,
                 applied_at,
-                checksum  
+                checksum,
+                git_commit_hash
             FROM
                 jetbase_migrations
             {"WHERE migration_type = " + f"'{migration_type.value}'" if migration_type else ""}
@@ -329,6 +361,8 @@ class QueryMethod(Enum):
     CREATE_MIGRATIONS_TABLE_STMT = "create_migrations_table_stmt"
     INSERT_VERSION_STMT = "insert_version_stmt"
     DELETE_VERSION_STMT = "delete_version_stmt"
+    ADD_GIT_COMMIT_HASH_COLUMN_STMT = "add_git_commit_hash_column_stmt"
+    GET_VERSIONED_MIGRATIONS_QUERY = "get_versioned_migrations_query"
     LATEST_VERSIONS_QUERY = "latest_versions_query"
     LATEST_VERSIONS_BY_STARTING_VERSION_QUERY = (
         "latest_versions_by_starting_version_query"

--- a/jetbase/database/queries/clickhouse.py
+++ b/jetbase/database/queries/clickhouse.py
@@ -16,7 +16,8 @@ class ClickHouseQueries(BaseQueries):
                 filename String,
                 migration_type String,
                 applied_at DateTime64(6) DEFAULT now64(6),
-                checksum String
+                checksum String,
+                git_commit_hash Nullable(String)
             ) ENGINE = MergeTree()
             ORDER BY order_executed
             """
@@ -26,16 +27,23 @@ class ClickHouseQueries(BaseQueries):
     def insert_version_stmt() -> TextClause:
         return text(
             """
-            INSERT INTO jetbase_migrations (order_executed, version, description, filename, migration_type, checksum, applied_at) 
-            SELECT 
+            INSERT INTO jetbase_migrations (order_executed, version, description, filename, migration_type, checksum, git_commit_hash, applied_at)
+            SELECT
                 (SELECT COALESCE(MAX(order_executed), 0) + 1 FROM jetbase_migrations),
-                :version, 
-                :description, 
-                :filename, 
-                :migration_type, 
+                :version,
+                :description,
+                :filename,
+                :migration_type,
                 :checksum,
+                :git_commit_hash,
                 now64(6)
             """
+        )
+
+    @staticmethod
+    def add_git_commit_hash_column_stmt() -> TextClause:
+        return text(
+            "ALTER TABLE jetbase_migrations ADD COLUMN IF NOT EXISTS git_commit_hash Nullable(String)"
         )
 
     @staticmethod
@@ -167,13 +175,14 @@ class ClickHouseQueries(BaseQueries):
     ) -> TextClause:
         query: str = f"""
             SELECT
-                order_executed, 
-                version, 
+                order_executed,
+                version,
                 description,
                 filename,
                 migration_type,
                 applied_at,
-                checksum  
+                checksum,
+                git_commit_hash
             FROM
                 jetbase_migrations
             {"WHERE migration_type = " + f"'{migration_type.value}'" if migration_type else ""}

--- a/jetbase/database/queries/databricks.py
+++ b/jetbase/database/queries/databricks.py
@@ -22,7 +22,8 @@ class DatabricksQueries(BaseQueries):
                 filename STRING NOT NULL,
                 migration_type STRING NOT NULL,
                 applied_at TIMESTAMP NOT NULL,
-                checksum STRING NOT NULL
+                checksum STRING NOT NULL,
+                git_commit_hash STRING
             )
             """
         )
@@ -31,10 +32,14 @@ class DatabricksQueries(BaseQueries):
     def insert_version_stmt() -> TextClause:
         return text(
             """
-            INSERT INTO jetbase_migrations (version, description, filename, migration_type, checksum, applied_at) 
-            VALUES (:version, :description, :filename, :migration_type, :checksum, CURRENT_TIMESTAMP())
+            INSERT INTO jetbase_migrations (version, description, filename, migration_type, checksum, git_commit_hash, applied_at)
+            VALUES (:version, :description, :filename, :migration_type, :checksum, :git_commit_hash, CURRENT_TIMESTAMP())
             """
         )
+
+    @staticmethod
+    def add_git_commit_hash_column_stmt() -> TextClause:
+        return text("ALTER TABLE jetbase_migrations ADD COLUMN git_commit_hash STRING")
 
     @staticmethod
     def check_if_migrations_table_exists_query() -> TextClause:

--- a/jetbase/database/queries/default_queries.py
+++ b/jetbase/database/queries/default_queries.py
@@ -22,13 +22,29 @@ CREATE TABLE IF NOT EXISTS jetbase_migrations (
     filename VARCHAR(512) NOT NULL,
     migration_type VARCHAR(32) NOT NULL,
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    checksum VARCHAR(64) NOT NULL
+    checksum VARCHAR(64) NOT NULL,
+    git_commit_hash VARCHAR(40)
 )
 """)
 
 INSERT_VERSION_STMT: TextClause = text("""
-INSERT INTO jetbase_migrations (version, description, filename, migration_type, checksum) 
-VALUES (:version, :description, :filename, :migration_type, :checksum)
+INSERT INTO jetbase_migrations (version, description, filename, migration_type, checksum, git_commit_hash)
+VALUES (:version, :description, :filename, :migration_type, :checksum, :git_commit_hash)
+""")
+
+ADD_GIT_COMMIT_HASH_COLUMN_STMT: TextClause = text("""
+ALTER TABLE jetbase_migrations ADD COLUMN IF NOT EXISTS git_commit_hash VARCHAR(40)
+""")
+
+GET_VERSIONED_MIGRATIONS_QUERY: TextClause = text(f"""
+    SELECT
+        version, filename, git_commit_hash
+    FROM
+        jetbase_migrations
+    WHERE
+        migration_type = '{MigrationType.VERSIONED.value}'
+    ORDER BY
+        order_executed DESC
 """)
 
 DELETE_VERSION_STMT: TextClause = text(f"""

--- a/jetbase/database/queries/mysql.py
+++ b/jetbase/database/queries/mysql.py
@@ -22,9 +22,16 @@ class MySQLQueries(BaseQueries):
                 filename VARCHAR(512) NOT NULL,
                 migration_type VARCHAR(32) NOT NULL,
                 applied_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
-                checksum VARCHAR(64) NOT NULL
+                checksum VARCHAR(64) NOT NULL,
+                git_commit_hash VARCHAR(40)
             )
             """
+        )
+
+    @staticmethod
+    def add_git_commit_hash_column_stmt() -> TextClause:
+        return text(
+            "ALTER TABLE jetbase_migrations ADD COLUMN git_commit_hash VARCHAR(40)"
         )
 
     @staticmethod

--- a/jetbase/database/queries/snowflake.py
+++ b/jetbase/database/queries/snowflake.py
@@ -31,7 +31,8 @@ class SnowflakeQueries(BaseQueries):
                 filename VARCHAR(512) NOT NULL,
                 migration_type VARCHAR(32) NOT NULL,
                 applied_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP() NOT NULL,
-                checksum VARCHAR(64) NOT NULL
+                checksum VARCHAR(64) NOT NULL,
+                git_commit_hash VARCHAR(40)
             )
             """
         )

--- a/jetbase/database/queries/sqlite.py
+++ b/jetbase/database/queries/sqlite.py
@@ -31,10 +31,25 @@ class SQLiteQueries(BaseQueries):
             filename TEXT NOT NULL,
             migration_type TEXT NOT NULL,
             applied_at TEXT DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
-            checksum TEXT
+            checksum TEXT,
+            git_commit_hash TEXT
         );
         """
         )
+
+    @staticmethod
+    def add_git_commit_hash_column_stmt() -> TextClause:
+        """
+        Get SQLite statement to add the git_commit_hash column.
+
+        Uses TEXT for SQLite compatibility. SQLite does not support
+        ADD COLUMN IF NOT EXISTS, so callers must guard against the
+        column already existing.
+
+        Returns:
+            TextClause: SQLAlchemy text clause for the ALTER TABLE statement.
+        """
+        return text("ALTER TABLE jetbase_migrations ADD COLUMN git_commit_hash TEXT")
 
     @staticmethod
     def check_if_migrations_table_exists_query() -> TextClause:

--- a/jetbase/engine/git.py
+++ b/jetbase/engine/git.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+
+
+def _run_git(*args: str) -> str | None:
+    """
+    Run a git command in the current working directory.
+
+    Args:
+        *args: Arguments to pass to the git executable (excluding 'git').
+
+    Returns:
+        str | None: The stripped stdout of the command, or None if git is
+            unavailable or the command fails (e.g. not inside a git repo).
+    """
+    try:
+        result: subprocess.CompletedProcess[str] = subprocess.run(
+            ["git", *args],
+            cwd=os.getcwd(),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    return result.stdout.strip()
+
+
+def get_current_commit_hash() -> str | None:
+    """
+    Get the git commit hash currently checked out.
+
+    Returns:
+        str | None: The full commit hash of HEAD, or None if git is not
+            available or the current directory is not inside a git repository.
+    """
+    return _run_git("rev-parse", "HEAD")
+
+
+def get_repo_root() -> str | None:
+    """
+    Get the absolute path to the root of the current git repository.
+
+    Returns:
+        str | None: The repository root path, or None if git is not available
+            or the current directory is not inside a git repository.
+    """
+    return _run_git("rev-parse", "--show-toplevel")
+
+
+def read_file_at_commit(commit_hash: str, repo_relative_path: str) -> str | None:
+    """
+    Read the contents of a file as it existed at a specific commit.
+
+    Uses ``git show <commit_hash>:<path>`` to retrieve the file content
+    without modifying the working tree or HEAD.
+
+    Args:
+        commit_hash (str): The commit hash to read the file from.
+        repo_relative_path (str): Path to the file relative to the repository
+            root, using forward slashes.
+
+    Returns:
+        str | None: The file content, or None if the file does not exist at
+            that commit or git is unavailable.
+    """
+    return _run_git("show", f"{commit_hash}:{repo_relative_path}")

--- a/jetbase/engine/validation.py
+++ b/jetbase/engine/validation.py
@@ -12,6 +12,7 @@ from jetbase.engine.version import (
 )
 from jetbase.exceptions import (
     ChecksumMismatchError,
+    MissingMigrationFileError,
     OutOfOrderMigrationError,
 )
 from jetbase.repositories.migrations_repo import (
@@ -82,11 +83,11 @@ def validate_migrated_versions_in_current_migration_files(
         None: Returns silently if all files are present.
 
     Raises:
-        FileNotFoundError: If any migrated version is missing its file.
+        MissingMigrationFileError: If any migrated version is missing its file.
     """
     for migrated_version in migrated_versions:
         if migrated_version not in current_migration_filepaths_by_version:
-            raise FileNotFoundError(
+            raise MissingMigrationFileError(
                 f"Version {migrated_version} has been migrated but is missing from the current migration files."
             )
 
@@ -188,7 +189,8 @@ def run_migration_validations(
 
     Raises:
         DuplicateMigrationVersionError: If duplicate versions are found.
-        FileNotFoundError: If migration files are missing.
+        MissingMigrationFileError: If a migrated version's file is missing.
+        FileNotFoundError: If repeatable migration files are missing.
         OutOfOrderMigrationError: If out-of-order migrations are detected.
         ChecksumMismatchError: If file checksums don't match stored values.
     """

--- a/jetbase/exceptions.py
+++ b/jetbase/exceptions.py
@@ -76,6 +76,22 @@ class VersionNotFoundError(Exception):
     pass
 
 
+class MissingMigrationFileError(FileNotFoundError):
+    """
+    Raised when an already-applied migration's file is missing locally.
+
+    This occurs during an upgrade when a version recorded in the
+    jetbase_migrations table has no corresponding file in the migrations
+    directory (for example, after checking out an older branch or release).
+
+    Subclasses FileNotFoundError so existing callers that handle the missing
+    file generically keep working, while the automatic safe-rollback flow can
+    catch this more specific condition.
+    """
+
+    pass
+
+
 class DirectoryNotFoundError(Exception):
     """
     Raised when the required Jetbase directories do not exist.

--- a/jetbase/models.py
+++ b/jetbase/models.py
@@ -19,6 +19,9 @@ class MigrationRecord:
             'RUNS_ALWAYS', or 'RUNS_ON_CHANGE').
         applied_at (dt.datetime): Timestamp when the migration was applied.
         checksum (str): SHA256 checksum of the migration's SQL statements.
+        git_commit_hash (str | None): The git commit hash checked out when the
+            migration was applied, or None if it was applied outside a git
+            repository or before this column existed.
     """
 
     order_executed: int
@@ -28,6 +31,29 @@ class MigrationRecord:
     migration_type: str
     applied_at: dt.datetime
     checksum: str
+    git_commit_hash: str | None = None
+
+
+@dataclass
+class AppliedVersionedMigration:
+    """
+    A lightweight view of an applied versioned migration.
+
+    Used by the automatic safe-rollback flow, which needs the version,
+    filename, and recorded git commit hash for each applied versioned
+    migration without the full MigrationRecord shape.
+
+    Attributes:
+        version (str): The version string of the migration.
+        filename (str): The original filename of the migration file.
+        git_commit_hash (str | None): The git commit hash checked out when
+            the migration was applied, or None if it was applied outside a
+            git repository or before this column existed.
+    """
+
+    version: str
+    filename: str
+    git_commit_hash: str | None
 
 
 @dataclass

--- a/jetbase/repositories/migrations_repo.py
+++ b/jetbase/repositories/migrations_repo.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Result, Row, text
+from sqlalchemy.exc import DatabaseError
 
 from jetbase.database.connection import get_db_connection
 from jetbase.database.queries.base import QueryMethod
@@ -7,9 +8,10 @@ from jetbase.engine.checksum import calculate_checksum
 from jetbase.engine.file_parser import (
     get_description_from_filename,
 )
+from jetbase.engine.git import get_current_commit_hash
 from jetbase.enums import MigrationDirectionType, MigrationType
 from jetbase.exceptions import VersionNotFoundError
-from jetbase.models import MigrationRecord
+from jetbase.models import AppliedVersionedMigration, MigrationRecord
 
 
 def run_migration(
@@ -54,6 +56,7 @@ def run_migration(
 
             description: str = get_description_from_filename(filename=filename)
             checksum: str = calculate_checksum(sql_statements=sql_statements)
+            git_commit_hash: str | None = get_current_commit_hash()
 
             connection.execute(
                 statement=get_query(QueryMethod.INSERT_VERSION_STMT),
@@ -63,6 +66,7 @@ def run_migration(
                     "filename": filename,
                     "migration_type": migration_type.value,
                     "checksum": checksum,
+                    "git_commit_hash": git_commit_hash,
                 },
             )
 
@@ -144,16 +148,52 @@ def create_migrations_table_if_not_exists() -> None:
     Create the jetbase_migrations table if it doesn't already exist.
 
     Creates the table used to track applied migrations, including
-    columns for version, description, filename, checksum, and timestamps.
+    columns for version, description, filename, checksum, timestamps, and
+    the git commit hash. Pre-existing tables created before the
+    git_commit_hash column existed are upgraded in place as part of this
+    procedure, so the rest of the codebase can assume the column is present.
 
     Returns:
-        None: Table is created as a side effect.
+        None: Table is created (and migrated) as a side effect.
     """
 
     with get_db_connection() as connection:
         connection.execute(
             statement=get_query(QueryMethod.CREATE_MIGRATIONS_TABLE_STMT)
         )
+        try:
+            connection.execute(
+                statement=get_query(QueryMethod.ADD_GIT_COMMIT_HASH_COLUMN_STMT)
+            )
+        except DatabaseError:
+            # Column already exists on a dialect without ADD COLUMN IF NOT EXISTS.
+            pass
+
+
+def get_versioned_migrations_desc() -> list[AppliedVersionedMigration]:
+    """
+    Get all applied versioned migrations ordered newest-first.
+
+    Used by the automatic safe-rollback flow to determine which applied
+    migrations are missing their files and to recover the git commit hash
+    recorded for the latest applied migration.
+
+    Returns:
+        list[AppliedVersionedMigration]: Applied versioned migrations ordered
+            by execution order descending (most recent first).
+    """
+    with get_db_connection() as connection:
+        results: Result[tuple[str, str, str | None]] = connection.execute(
+            statement=get_query(QueryMethod.GET_VERSIONED_MIGRATIONS_QUERY)
+        )
+        return [
+            AppliedVersionedMigration(
+                version=row.version,
+                filename=row.filename,
+                git_commit_hash=row.git_commit_hash,
+            )
+            for row in results.fetchall()
+        ]
 
 
 def get_latest_versions(
@@ -268,6 +308,7 @@ def get_migration_records() -> list[MigrationRecord]:
                 migration_type=row.migration_type,
                 applied_at=row.applied_at,
                 checksum=row.checksum,
+                git_commit_hash=row.git_commit_hash,
             )
             for row in results.fetchall()
         ]
@@ -446,6 +487,7 @@ def fetch_repeatable_migrations() -> list[MigrationRecord]:
                 migration_type=row.migration_type,
                 applied_at=row.applied_at,
                 checksum=row.checksum,
+                git_commit_hash=row.git_commit_hash,
             )
             for row in results.fetchall()
         ]

--- a/tests/cli/test_auto_rollback.py
+++ b/tests/cli/test_auto_rollback.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+
+from sqlalchemy import text
+
+from jetbase.cli.main import app
+from jetbase.exceptions import MissingMigrationFileError
+
+
+def _git(*args: str, cwd) -> None:
+    """Run a git command in cwd with a deterministic identity."""
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_upgrade_records_git_commit_hash_and_auto_rolls_back_missing_file(
+    runner, test_db_url, clean_db, setup_migrations_versions_only, tmp_path
+):
+    """End-to-end: hash is recorded, and --auto-rollback recovers a missing file."""
+    os.environ["JETBASE_SQLALCHEMY_URL"] = test_db_url
+
+    # Initialize a git repo containing the migration files (cwd is tmp_path here).
+    _git("init", cwd=tmp_path)
+    _git("add", "-A", cwd=tmp_path)
+    _git("commit", "-m", "initial migrations", cwd=tmp_path)
+
+    migrations_dir = setup_migrations_versions_only
+
+    os.chdir("jetbase")
+    result = runner.invoke(app, ["upgrade"])
+    assert result.exit_code == 0, result.output
+
+    with clean_db.connect() as connection:
+        rows = connection.execute(
+            text(
+                "SELECT version, git_commit_hash FROM jetbase_migrations "
+                "WHERE migration_type = 'VERSIONED'"
+            )
+        ).fetchall()
+    assert len(rows) == 5
+    # Every applied versioned migration recorded the current commit hash.
+    assert all(row.git_commit_hash for row in rows)
+
+    # Delete the trailing (highest-version) migration file locally; it remains in git.
+    (migrations_dir / "V21__mi21.sql").unlink()
+
+    # Without the flag, the upgrade fails because an applied file is missing.
+    result_no_flag = runner.invoke(app, ["upgrade"])
+    assert result_no_flag.exit_code != 0
+    assert isinstance(result_no_flag.exception, MissingMigrationFileError)
+
+    # With --auto-rollback, V21 is rolled back (its rollback SQL recovered from git)
+    # and the upgrade re-runs from the V4 baseline.
+    result_auto = runner.invoke(app, ["upgrade", "--auto-rollback"])
+    assert result_auto.exit_code == 0, result_auto.output
+
+    with clean_db.connect() as connection:
+        remaining = connection.execute(
+            text(
+                "SELECT version FROM jetbase_migrations "
+                "WHERE migration_type = 'VERSIONED'"
+            )
+        ).fetchall()
+    versions = {row.version for row in remaining}
+    assert "21" not in versions
+    assert len(remaining) == 4

--- a/tests/unit/commands/test_safe_rollback.py
+++ b/tests/unit/commands/test_safe_rollback.py
@@ -1,0 +1,123 @@
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from jetbase.commands.safe_rollback import attempt_safe_rollback
+from jetbase.enums import MigrationDirectionType
+from jetbase.models import AppliedVersionedMigration
+
+
+@contextmanager
+def _noop_lock():
+    yield
+
+
+def _applied(*specs: tuple[str, str, str | None]) -> list[AppliedVersionedMigration]:
+    """Build a newest-first list of applied versioned migrations."""
+    return [
+        AppliedVersionedMigration(version=v, filename=f, git_commit_hash=h)
+        for v, f, h in specs
+    ]
+
+
+class TestAttemptSafeRollback:
+    """Tests for attempt_safe_rollback."""
+
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_returns_false_when_no_applied_migrations(self, mock_applied: Mock) -> None:
+        """Nothing applied -> nothing to roll back."""
+        mock_applied.return_value = []
+
+        assert attempt_safe_rollback() is False
+
+    @patch("jetbase.commands.safe_rollback.get_repo_root", return_value="/repo")
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_returns_false_when_latest_hash_missing(
+        self, mock_applied: Mock, _mock_root: Mock
+    ) -> None:
+        """Requirement 4: NULL hash on the latest applied migration -> fall back."""
+        mock_applied.return_value = _applied(
+            ("2", "V2__b.sql", None), ("1", "V1__a.sql", "abc")
+        )
+
+        assert attempt_safe_rollback() is False
+
+    @patch("jetbase.commands.safe_rollback.get_repo_root", return_value=None)
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_returns_false_when_not_in_git_repo(
+        self, mock_applied: Mock, _mock_root: Mock
+    ) -> None:
+        """Requirement 4: outside a git repo -> fall back."""
+        mock_applied.return_value = _applied(("1", "V1__a.sql", "abc"))
+
+        assert attempt_safe_rollback() is False
+
+    @patch("jetbase.commands.safe_rollback.get_migration_filepaths_by_version")
+    @patch("jetbase.commands.safe_rollback.get_repo_root", return_value="/repo")
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_returns_false_when_all_files_present(
+        self, mock_applied: Mock, _mock_root: Mock, mock_files: Mock
+    ) -> None:
+        """No missing trailing files -> nothing to roll back."""
+        mock_applied.return_value = _applied(
+            ("2", "V2__b.sql", "abc"), ("1", "V1__a.sql", "abc")
+        )
+        mock_files.return_value = {"1": "/p/V1__a.sql", "2": "/p/V2__b.sql"}
+
+        assert attempt_safe_rollback() is False
+
+    @patch("jetbase.commands.safe_rollback.run_migration")
+    @patch("jetbase.commands.safe_rollback._get_rollback_statements")
+    @patch("jetbase.commands.safe_rollback.migration_lock", _noop_lock)
+    @patch("jetbase.commands.safe_rollback.get_migration_filepaths_by_version")
+    @patch("jetbase.commands.safe_rollback.get_repo_root", return_value="/repo")
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_rolls_back_trailing_missing_to_baseline(
+        self,
+        mock_applied: Mock,
+        _mock_root: Mock,
+        mock_files: Mock,
+        mock_stmts: Mock,
+        mock_run: Mock,
+    ) -> None:
+        """V3, V2 missing while V1 exists -> roll back V3 then V2, keep V1."""
+        mock_applied.return_value = _applied(
+            ("3", "V3__c.sql", "head"),
+            ("2", "V2__b.sql", "head"),
+            ("1", "V1__a.sql", "head"),
+        )
+        mock_files.return_value = {"1": "/p/V1__a.sql"}
+        mock_stmts.return_value = ["DROP TABLE x"]
+
+        assert attempt_safe_rollback() is True
+
+        rolled_back_versions = [
+            call.kwargs["version"] for call in mock_run.call_args_list
+        ]
+        assert rolled_back_versions == ["3", "2"]
+        assert all(
+            call.kwargs["migration_operation"] == MigrationDirectionType.ROLLBACK
+            for call in mock_run.call_args_list
+        )
+
+    @patch("jetbase.commands.safe_rollback.run_migration")
+    @patch("jetbase.commands.safe_rollback._get_rollback_statements", return_value=None)
+    @patch("jetbase.commands.safe_rollback.migration_lock", _noop_lock)
+    @patch("jetbase.commands.safe_rollback.get_migration_filepaths_by_version")
+    @patch("jetbase.commands.safe_rollback.get_repo_root", return_value="/repo")
+    @patch("jetbase.commands.safe_rollback.get_versioned_migrations_desc")
+    def test_returns_false_when_recovery_fails(
+        self,
+        mock_applied: Mock,
+        _mock_root: Mock,
+        mock_files: Mock,
+        _mock_stmts: Mock,
+        mock_run: Mock,
+    ) -> None:
+        """If a missing file cannot be recovered from git, abort safely."""
+        mock_applied.return_value = _applied(
+            ("2", "V2__b.sql", "head"), ("1", "V1__a.sql", "head")
+        )
+        mock_files.return_value = {"1": "/p/V1__a.sql"}
+
+        assert attempt_safe_rollback() is False
+        mock_run.assert_not_called()

--- a/tests/unit/engine/test_git.py
+++ b/tests/unit/engine/test_git.py
@@ -1,0 +1,83 @@
+import subprocess
+from unittest.mock import Mock, patch
+
+from jetbase.engine.git import (
+    get_current_commit_hash,
+    get_repo_root,
+    read_file_at_commit,
+)
+
+
+class TestGetCurrentCommitHash:
+    """Tests for the get_current_commit_hash function."""
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_hash(self, mock_run: Mock) -> None:
+        """Test the stripped HEAD hash is returned on success."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        assert get_current_commit_hash() == "abc123"
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_none_when_not_a_repo(self, mock_run: Mock) -> None:
+        """Test None is returned when git exits non-zero (not a repo)."""
+        mock_run.side_effect = subprocess.CalledProcessError(128, ["git"])
+
+        assert get_current_commit_hash() is None
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_none_when_git_missing(self, mock_run: Mock) -> None:
+        """Test None is returned when the git executable is unavailable."""
+        mock_run.side_effect = FileNotFoundError()
+
+        assert get_current_commit_hash() is None
+
+
+class TestGetRepoRoot:
+    """Tests for the get_repo_root function."""
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_root(self, mock_run: Mock) -> None:
+        """Test the repository root path is returned on success."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="/repo/root\n", stderr=""
+        )
+
+        assert get_repo_root() == "/repo/root"
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_none_outside_repo(self, mock_run: Mock) -> None:
+        """Test None is returned when outside a git repository."""
+        mock_run.side_effect = subprocess.CalledProcessError(128, ["git"])
+
+        assert get_repo_root() is None
+
+
+class TestReadFileAtCommit:
+    """Tests for the read_file_at_commit function."""
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_content(self, mock_run: Mock) -> None:
+        """Test file content at a commit is returned."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="-- upgrade\nSELECT 1;\n", stderr=""
+        )
+
+        content = read_file_at_commit("abc123", "jetbase/migrations/V1__a.sql")
+
+        assert content == "-- upgrade\nSELECT 1;"
+        called_args = mock_run.call_args.args[0]
+        assert called_args == [
+            "git",
+            "show",
+            "abc123:jetbase/migrations/V1__a.sql",
+        ]
+
+    @patch("jetbase.engine.git.subprocess.run")
+    def test_returns_none_when_file_absent(self, mock_run: Mock) -> None:
+        """Test None is returned when the file is absent at that commit."""
+        mock_run.side_effect = subprocess.CalledProcessError(128, ["git"])
+
+        assert read_file_at_commit("abc123", "missing.sql") is None

--- a/tests/unit/engine/test_validation.py
+++ b/tests/unit/engine/test_validation.py
@@ -13,6 +13,7 @@ from jetbase.engine.validation import (
 from jetbase.exceptions import (
     ChecksumMismatchError,
     DirectoryNotFoundError,
+    MissingMigrationFileError,
     OutOfOrderMigrationError,
 )
 
@@ -53,7 +54,7 @@ class TestValidateMigratedVersionsInCurrentMigrationFiles:
         migrated_versions = ["1", "2"]
         filepaths = {"1": "/path/V1__test.sql"}
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(MissingMigrationFileError):
             validate_migrated_versions_in_current_migration_files(
                 migrated_versions, filepaths
             )


### PR DESCRIPTION
## Summary

Adds two linked capabilities to `jetbase upgrade`:

1. **Migration provenance** - every applied migration now records the git commit hash that was checked out at the moment it ran, in a new nullable `git_commit_hash` column on `jetbase_migrations`.
2. **Automatic safe rollback** (opt-in `--auto-rollback`) - when an *already-applied* migration's file is missing locally (e.g. after checking out an older branch/release), the upgrade no longer just errors out. Instead it rolls the database back to the latest applied migration whose file still exists, then re-runs the upgrade from that baseline. The rollback SQL for the missing files is recovered **read-only** from the recorded commit via `git show` - the working tree and `HEAD` are never touched.

## Motivation

Previously, running `upgrade` when a migrated version's file was absent raised `FileNotFoundError` and stopped, leaving the operator to manually restore files or hand-fix the migrations table. This is common when switching between branches/releases whose `migrations/` directories diverge. With the recorded commit hash, jetbase can self-heal: roll back to a state that matches the current files and continue.

## What changed

### `git_commit_hash` column
- Added (nullable) to the `CREATE TABLE` statement for all six dialects (Postgres, SQLite, MySQL, Snowflake, Databricks, ClickHouse).
- `run_migration` records `get_current_commit_hash()` on every versioned / first-time-repeatable insert; `INSERT` statements updated for the default, ClickHouse, and Databricks dialects.
- Existing tables are upgraded in place via an idempotent, dialect-agnostic `ensure_git_commit_hash_column()` (`ALTER TABLE ADD COLUMN`, guarded by SQLAlchemy reflection) run at the start of each upgrade.

### Automatic safe rollback
- New `jetbase/engine/git.py` - read-only git helpers (`get_current_commit_hash`, `get_repo_root`, `read_file_at_commit`) using `subprocess`, no new dependencies.
- New `jetbase/commands/safe_rollback.py` - `attempt_safe_rollback()` determines the baseline, recovers missing files' rollback SQL from the recorded commit, and rolls back under the migration lock.
- `upgrade_cmd` gains an `auto_rollback` param and a `--auto-rollback` CLI flag; on a missing-file error it attempts the rollback, then re-validates and re-upgrades from the new baseline.
- New `MissingMigrationFileError` (subclasses `FileNotFoundError` for backward compatibility) distinguishes the missing-applied-file case so the recovery flow targets it precisely.

### Graceful fallback (preserves old behaviour)
If the repo isn't a git checkout, the latest applied migration has no recorded hash, the missing files aren't a contiguous trailing run, or a file can't be recovered from git, `attempt_safe_rollback()` returns `False` and the original error is re-raised.

## Scope notes
- The hash is recorded on insert; it is **not** refreshed when repeatable migrations re-run.
- Auto-rollback handles the contiguous trailing-missing-files case; a non-contiguous gap falls through to the original error.
