### PR TITLE
allow postgres custom schemas

### DIFF
--- a/jetbase/database/queries/default_queries.py
+++ b/jetbase/database/queries/default_queries.py
@@ -78,7 +78,7 @@ CHECK_IF_MIGRATIONS_TABLE_EXISTS_QUERY: TextClause = text("""
 SELECT EXISTS (
     SELECT 1
     FROM information_schema.tables
-    WHERE table_schema = 'public'
+    WHERE table_schema = current_schema()
       AND table_name = 'jetbase_migrations'
 )
 """)
@@ -87,7 +87,7 @@ CHECK_IF_LOCK_TABLE_EXISTS_QUERY: TextClause = text("""
 SELECT EXISTS (
     SELECT 1
     FROM information_schema.tables
-    WHERE table_schema = 'public'
+    WHERE table_schema = current_schema()
       AND table_name = 'jetbase_lock'
 )
 """)

--- a/tests/cli/test_postgres_schema.py
+++ b/tests/cli/test_postgres_schema.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+from sqlalchemy import text
+
+from jetbase.cli.main import app
+from jetbase.repositories.migrations_repo import (
+    create_migrations_table_if_not_exists,
+    migrations_table_exists,
+)
+from tests.utils import is_postgres
+
+
+@pytest.mark.skipif(not is_postgres(), reason="postgres_schema is PostgreSQL-only")
+def test_migrations_table_exists_detects_custom_schema(
+    test_db_url, custom_postgres_schema, setup_migrations_versions_only
+):
+    os.chdir("jetbase")
+
+    create_migrations_table_if_not_exists()
+
+    assert migrations_table_exists() is True
+
+
+@pytest.mark.skipif(not is_postgres(), reason="postgres_schema is PostgreSQL-only")
+def test_upgrade_is_idempotent_in_custom_schema(
+    runner,
+    test_db_url,
+    clean_db,
+    custom_postgres_schema,
+    setup_migrations_versions_only,
+    caplog,
+):
+    os.chdir("jetbase")
+    assert runner.invoke(app, ["upgrade"]).exit_code == 0
+    caplog.clear()
+    second_run = runner.invoke(app, ["upgrade"])
+    assert second_run.exit_code == 0, second_run.exception
+    assert "up to date" in caplog.text.lower()
+    with clean_db.connect() as connection:
+        count = connection.execute(
+            text(f"SELECT COUNT(*) FROM {custom_postgres_schema}.jetbase_migrations")
+        ).scalar()
+        assert count == 5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,27 @@ def clean_db(test_db_url):
     engine.dispose()
 
     _get_engine.cache_clear()
+
+
+CUSTOM_SCHEMA = "jetbase_test_schema"
+
+
+@pytest.fixture
+def custom_postgres_schema(clean_db):
+    """Run jetbase against a non-public Postgres schema."""
+
+    def drop_schema():
+        with clean_db.begin() as connection:
+            connection.execute(text(f"DROP SCHEMA IF EXISTS {CUSTOM_SCHEMA} CASCADE"))
+
+    drop_schema()
+    with clean_db.begin() as connection:
+        connection.execute(text(f"CREATE SCHEMA {CUSTOM_SCHEMA}"))
+    os.environ["JETBASE_POSTGRES_SCHEMA"] = CUSTOM_SCHEMA
+    _get_engine.cache_clear()
+
+    yield CUSTOM_SCHEMA
+
+    os.environ.pop("JETBASE_POSTGRES_SCHEMA", None)
+    _get_engine.cache_clear()
+    drop_schema()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,11 @@
 import os
 
 
-def is_clickhouse():
-    url = os.environ.get("JETBASE_SQLALCHEMY_URL", "")
+def is_clickhouse() -> bool:
+    url: str = os.environ.get("JETBASE_SQLALCHEMY_URL", "")
     return "clickhouse" in url.lower()
+
+
+def is_postgres() -> bool:
+    url: str = os.environ.get("JETBASE_SQLALCHEMY_URL", "")
+    return "postgres" in url.lower()


### PR DESCRIPTION
Fixes #94 

Jetbase can now be successfully run from any schema in postgres instead of just the default schema